### PR TITLE
[Feat]  AI 일기 기능 초기 API 및 DTO 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/emory/emoryserver/ai/controller/ChatController.java
+++ b/src/main/java/emory/emoryserver/ai/controller/ChatController.java
@@ -1,0 +1,54 @@
+package emory.emoryserver.ai.controller;
+
+
+import emory.emoryserver.ai.dto.chat.ChatMessageRequestDto;
+import emory.emoryserver.ai.dto.chat.ChatSaveRequestDto;
+import emory.emoryserver.ai.dto.chat.ChatStartRequestDto;
+import emory.emoryserver.ai.dto.chat.DiaryGenerateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "AI Chat", description = "AI 실시간 대화 API")
+@RestController
+@RequestMapping("/ai/chat")
+public class ChatController {
+
+    @Operation(summary = "AI 실시간 대화 시작", description = "선택한 감정 및 캘린더 일정을 기반으로 AI와 음성 대화를 시작합니다.")
+    @PostMapping("/start")
+    public void startSession(@RequestBody ChatStartRequestDto request) {
+        //세션 시작 로직
+    }
+
+    @Operation(summary = "사용자 메시지 전송", description = "사용자의 음성메시지를 전송해 대화 상태 갱신")
+    @PostMapping("/message")
+    public void sendMessage(@RequestBody ChatMessageRequestDto request) {
+        //메시지 처리 로직
+    }
+
+    @Operation(summary = "대화 상태 모니터링", description = "대화 중 상태 전달을 위한 보조 메시지. 예) 타이핑 중 여부 확인")
+    @GetMapping("/status")
+    public void getStatus(@RequestParam String sessionId) {
+        //상태 전달 로직
+    }
+
+    @Operation(summary = "AI 실시간 대화 종료")
+    @PostMapping("/stop")
+    public void stopSession(@RequestParam String sessionId) {
+        // 세션 종료 로직
+    }
+    
+    @Operation(summary = "대화 결과 저장")
+    @PostMapping("/save")
+    public void saveResult(@RequestBody ChatSaveRequestDto request) {
+        //결과 저장 로직
+        // 저장할 대화 내용 처리
+    }
+
+    @Operation(summary = "AI 일기 생성", description = "저장된 대화 내용 기반으로 AI가 일기를 생성합니다.")
+    @PostMapping("/generate-diary")
+    public void generateDiary(@RequestBody DiaryGenerateRequestDto request) {
+        // AI 일기 생성 로직
+        // 세션 id로 대화내용 찾아서 일기 생성
+    }
+}

--- a/src/main/java/emory/emoryserver/ai/controller/EmotionController.java
+++ b/src/main/java/emory/emoryserver/ai/controller/EmotionController.java
@@ -1,0 +1,37 @@
+package emory.emoryserver.ai.controller;
+
+import emory.emoryserver.ai.dto.emotion.EmotionAnalyzeRequestDto;
+import emory.emoryserver.ai.dto.emotion.EmotionFeedbackRequestDto;
+import emory.emoryserver.ai.dto.emotion.EmotionFeedbackResponseDto;
+import emory.emoryserver.ai.dto.emotion.EmotionVerifyRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AI Emotion", description = "감정 분석 및 감정 진위 판단 API")
+@RestController
+@RequestMapping("/ai/emotion")
+public class EmotionController {
+
+    @Operation(summary = "감정 분석", description = "사용자와 AI의 대화 기반으로 감정을 분석합니다.")
+    @PostMapping("/analyze")
+    public void analyzeEmotion(@RequestBody EmotionAnalyzeRequestDto request) {
+        // 감정 분석 로직
+    }
+
+    @Operation(summary = "감정 진위 여부 판단", description = "사용자가 카테고리에서 선택한 감정과 실제 분석된 감정이 일치하는지 판단합니다.")
+    @PostMapping("/verify")
+    public void verifyEmotion(@RequestBody EmotionVerifyRequestDto request) {
+
+    }
+
+    @Operation(summary = "감정 피드백 메시지 생성", description = "감정 분석 결과와 원인을 바탕으로 위로 또는 피드백 메시지를 생성합니다.")
+    @PostMapping("/feedback-message")
+    public void generateEmotionFeedbackMessage(@RequestBody EmotionFeedbackRequestDto request) {
+        // 감정 위로 메시지 생성 로직
+    }
+}
+

--- a/src/main/java/emory/emoryserver/ai/controller/ImageController.java
+++ b/src/main/java/emory/emoryserver/ai/controller/ImageController.java
@@ -1,0 +1,21 @@
+package emory.emoryserver.ai.controller;
+
+import emory.emoryserver.ai.dto.image.ImageRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AI image", description = "감정 기반 이미지 및 컬러 생성 API")
+@RestController
+@RequestMapping("/ai/image")
+public class ImageController {
+
+    @Operation(summary = "AI 이미지 및 컬러 생성", description = "감정 및 일기 내용을 기반으로 하루를 상징하는 이미지와 컬러를 생성합니다.")
+    @PostMapping("/generate")
+    public void generateImage(@RequestBody ImageRequestDto request) {
+        // 이미지 및 컬러 생성 로직
+    }
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatEndRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatEndRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class ChatEndRequestDto {
     @Schema(description = "대화 세션 ID", example = "abc123-session")
     private String sessionId;

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatEndRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatEndRequestDto.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ChatEndRequestDto {
+    @Schema(description = "대화 세션 ID", example = "abc123-session")
+    private String sessionId;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageRequestDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ChatMessageRequestDto {
+    @Schema(description = "대화 세션 ID", example = "abc123-session")
+    private String sessionId;
+
+    @Schema(description = "사용자의 메시지", example = "오늘 너무 힘들었어")
+    private String userMessage;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class ChatMessageRequestDto {
     @Schema(description = "대화 세션 ID", example = "abc123-session")
     private String sessionId;

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageResponseDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class ChatMessageResponseDto {
     @Schema(description = "AI의 응답 메시지", example = "시험 보느라 고생 많았네요.")
     private String aiMessage;

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatMessageResponseDto.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ChatMessageResponseDto {
+    @Schema(description = "AI의 응답 메시지", example = "시험 보느라 고생 많았네요.")
+    private String aiMessage;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatSaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatSaveRequestDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ChatSaveRequestDto {
+    @Schema(description = "세션 ID", example = "abc123-session")
+    private String sessionId;
+
+    @Schema(description = "전체 대화 내용", example = "사용자: 힘들어 / AI: 시험 보느라 고생 많았네요.")
+    private String conversationLog;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatSaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatSaveRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class ChatSaveRequestDto {
     @Schema(description = "세션 ID", example = "abc123-session")
     private String sessionId;

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatStartRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatStartRequestDto.java
@@ -2,8 +2,9 @@ package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jdk.jfr.DataAmount;
+import lombok.Data;
 
-
+@Data
 public class ChatStartRequestDto {
 
     @Schema(description = "사용자 ID", example = "1")

--- a/src/main/java/emory/emoryserver/ai/dto/chat/ChatStartRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/ChatStartRequestDto.java
@@ -1,0 +1,17 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jdk.jfr.DataAmount;
+
+
+public class ChatStartRequestDto {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "선택한 감정 카테고리", example = "슬픔")
+    private String selectedEmotion;
+
+    @Schema(description =  "해당 날짜의 캘린더 일정 요약",example = "시험 있는 날")
+    private String calendarSummary;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/DiaryGenerateRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/DiaryGenerateRequestDto.java
@@ -1,0 +1,9 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class DiaryGenerateRequestDto {
+    @Schema(description = "대화 세션 ID", example = "abc123-session")
+    private String sessionId;
+
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/DiaryGenerateRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/DiaryGenerateRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class DiaryGenerateRequestDto {
     @Schema(description = "대화 세션 ID", example = "abc123-session")
     private String sessionId;

--- a/src/main/java/emory/emoryserver/ai/dto/chat/DiaryResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/DiaryResponseDto.java
@@ -1,0 +1,16 @@
+package emory.emoryserver.ai.dto.chat;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public class DiaryResponseDto {
+    @Schema(description = "AI가 생성한 일기 내용")
+    private String diaryText;
+
+    @Schema(description = "감정 태그", example = "슬픔")
+    private String emotion;
+
+    @Schema(description = "일기 생성 날짜", example = "2025-07-16")
+    private LocalDate date;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/chat/DiaryResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/chat/DiaryResponseDto.java
@@ -1,9 +1,11 @@
 package emory.emoryserver.ai.dto.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
 import java.time.LocalDate;
 
+@Data
 public class DiaryResponseDto {
     @Schema(description = "AI가 생성한 일기 내용")
     private String diaryText;

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionAnalyzeRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionAnalyzeRequestDto.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.ai.dto.emotion;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class EmotionAnalyzeRequestDto {
+    @Schema(description = "분석할 대화 내용", example = "오늘 하루 너무 지쳤어")
+    private String conversationText;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionAnalyzeRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionAnalyzeRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.emotion;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class EmotionAnalyzeRequestDto {
     @Schema(description = "분석할 대화 내용", example = "오늘 하루 너무 지쳤어")
     private String conversationText;

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.emotion;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class EmotionFeedbackRequestDto {
     @Schema(description = "분석된 감정", example = "불안")
     private String emotion;

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackRequestDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.ai.dto.emotion;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class EmotionFeedbackRequestDto {
+    @Schema(description = "분석된 감정", example = "불안")
+    private String emotion;
+
+    @Schema(description = "AI가 추론한 감정 원인", example = "내일 시험이 너무 걱정돼서")
+    private String reason;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackResponseDto.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.ai.dto.emotion;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class EmotionFeedbackResponseDto {
+    @Schema(description = "사용자에게 전달할 위로 또는 피드백 메시지")
+    private String message;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionFeedbackResponseDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.emotion;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class EmotionFeedbackResponseDto {
     @Schema(description = "사용자에게 전달할 위로 또는 피드백 메시지")
     private String message;

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionVerifyRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionVerifyRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.emotion;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class EmotionVerifyRequestDto {
     @Schema(description = "사용자가 선택한 감정", example = "슬픔")
     private String selectedEmotion;

--- a/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionVerifyRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/emotion/EmotionVerifyRequestDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.ai.dto.emotion;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class EmotionVerifyRequestDto {
+    @Schema(description = "사용자가 선택한 감정", example = "슬픔")
+    private String selectedEmotion;
+
+    @Schema(description = "AI가 분석할 텍스트", example = "하루 종일 마음이 가라앉았어")
+    private String text;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/image/ImageRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/image/ImageRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.image;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class ImageRequestDto {
     @Schema(description = "감정", example = "기쁨")
     private String emotion;

--- a/src/main/java/emory/emoryserver/ai/dto/image/ImageRequestDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/image/ImageRequestDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.ai.dto.image;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ImageRequestDto {
+    @Schema(description = "감정", example = "기쁨")
+    private String emotion;
+
+    @Schema(description = "일기 내용", example = "오늘은 친구들과 정말 즐거운 하루를 보냈어.")
+    private String diaryContent;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/image/ImageResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/image/ImageResponseDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.ai.dto.image;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ImageResponseDto {
+    @Schema(description = "생성된 이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "대표 색상", example = "#FFDDC1")
+    private String dominantColor;
+}

--- a/src/main/java/emory/emoryserver/ai/dto/image/ImageResponseDto.java
+++ b/src/main/java/emory/emoryserver/ai/dto/image/ImageResponseDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.ai.dto.image;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class ImageResponseDto {
     @Schema(description = "생성된 이미지 URL")
     private String imageUrl;

--- a/src/main/java/emory/emoryserver/aidiary/controller/DiaryEditController.java
+++ b/src/main/java/emory/emoryserver/aidiary/controller/DiaryEditController.java
@@ -1,0 +1,27 @@
+package emory.emoryserver.aidiary.controller;
+
+import emory.emoryserver.aidiary.dto.DiarySaveRequestDto;
+import emory.emoryserver.aidiary.dto.DiaryUpdateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Diary Edit", description = "일기 작성 및 수정 API")
+@RestController
+@RequestMapping("/diary")
+public class DiaryEditController {
+
+    @Operation(summary = "AI 일기 저장", description = "AI가 최종적으로 생성한 일기, 이미지, 컬러를 저장합니다.")
+    @PostMapping("/save")
+    public void saveDiary(@RequestBody DiarySaveRequestDto request) {
+        //일기 저장 로직
+    }
+
+    @Operation(summary = "AI 일기 수정", description = "사용자가 AI가 생성한 일기를 수정합니다.")
+    @PutMapping("/edit/{diaryId}")
+    public void updateDiary(@PathVariable long diaryId,
+                            @RequestBody DiaryUpdateRequestDto request) {
+        // 일기 수정 로직
+    }
+
+}

--- a/src/main/java/emory/emoryserver/aidiary/controller/FeedbackController.java
+++ b/src/main/java/emory/emoryserver/aidiary/controller/FeedbackController.java
@@ -1,0 +1,34 @@
+package emory.emoryserver.aidiary.controller;
+
+import emory.emoryserver.aidiary.dto.FeedbackSaveRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Diary Feedback", description = "사용자 선택형 피드백 저장 API")
+@RestController
+@RequestMapping("/diary/feedback")
+public class FeedbackController {
+
+    @Operation(summary = "피드백 항목 목록 조회", description = "사용자가 선택할 수 있는 피드백 항목 목록 반환합니다.")
+    @GetMapping("/options")
+    public ResponseEntity<List<String>> getFeedbackOptions() {
+        List<String> options = List.of(
+                "내 감정과 하루를 잘 반영했어요",
+                "내 감정과 하루를 잘 반영하지 못했어요",
+                "문맥이 이상해요",
+                "말투가 어색해요"
+        );
+        return ResponseEntity.ok(options);
+    }
+
+    @Operation(summary = "일기 선택형 피드백 저장", description = "사용자가 AI 일기에 대한 피드백을 선택하고 저장합니다.")
+    @PostMapping("/{diaryId}")
+    public void saveFeedback(@PathVariable Long DiaryId,
+                             @RequestBody FeedbackSaveRequestDto request) {
+        //선택형 피드백 저장 로직
+    }
+}

--- a/src/main/java/emory/emoryserver/aidiary/dto/DiarySaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/DiarySaveRequestDto.java
@@ -1,9 +1,11 @@
 package emory.emoryserver.aidiary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
 import java.time.LocalDate;
 
+@Data
 public class DiarySaveRequestDto {
     @Schema(description = "AI가 생성한 일기 내용")
     private String diaryText;

--- a/src/main/java/emory/emoryserver/aidiary/dto/DiarySaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/DiarySaveRequestDto.java
@@ -1,0 +1,22 @@
+package emory.emoryserver.aidiary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public class DiarySaveRequestDto {
+    @Schema(description = "AI가 생성한 일기 내용")
+    private String diaryText;
+
+    @Schema(description = "감정", example = "기쁨")
+    private String emotion;
+
+    @Schema(description = "일기 날짜", example = "2025-07-16")
+    private LocalDate date;
+
+    @Schema(description = "이미지 URL")
+    private String imageUrl;
+
+    @Schema(description = "대표 색상", example = "#A3C1DA")
+    private String color;
+}

--- a/src/main/java/emory/emoryserver/aidiary/dto/DiaryUpdateRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/DiaryUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.aidiary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class DiaryUpdateRequestDto {
+    @Schema(description = "수정된 일기 내용")
+    private String updatedText;
+}

--- a/src/main/java/emory/emoryserver/aidiary/dto/DiaryUpdateRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/DiaryUpdateRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.aidiary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class DiaryUpdateRequestDto {
     @Schema(description = "수정된 일기 내용")
     private String updatedText;

--- a/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveRequestDto.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.aidiary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class FeedbackSaveRequestDto {
+    @Schema(description = "선택한 피드백 항목", example = "말투가 어색해요")
+    private String selectedOption;
+}

--- a/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveRequestDto.java
@@ -1,7 +1,9 @@
 package emory.emoryserver.aidiary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
 
+@Data
 public class FeedbackSaveRequestDto {
     @Schema(description = "선택한 피드백 항목", example = "말투가 어색해요")
     private String selectedOption;


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#2 AI 일기 생성 및 분석 스웨거 API

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
1. `Chat, Emotion, Image, DiaryEdit, Feedback` 도메인별 컨트롤러 구현
2. AI Chat은 실시간 대화이지만 Swagger에 맞게 RESTful 형식으로 변환
3. Lombok 적용
4. `@Data` 적용된 각 컨트롤러에 맞는 request, response DTO 생성 후 컨트롤러에 requestDto 적용

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->



<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
DTO를 lombok과 Swagger 문서화용 `@Schema` 까지 포함해서 작성했습니다. 그냥 lombok 방식으로만 코드량을 줄여서 작성할지 봐주세요!!!


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>
**컨트롤러 클래스에 DTO 적용**
https://gnidinger.tistory.com/entry/SpringSpring-MVC-Controller-%ED%81%B4%EB%9E%98%EC%8A%A4%EC%97%90-DTO-%EC%A0%81%EC%9A%A9