### PR TITLE
[Feat] 로그인 API 구현 및 JWT 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,29 @@ repositories {
 }
 
 dependencies {
+	// Core
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// OpenAPI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	// Override vulnerable commons-lang3
+	implementation 'org.apache.commons:commons-lang3:3.14.0'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/emory/emoryserver/domain/admin/controller/AdminController.java
+++ b/src/main/java/emory/emoryserver/domain/admin/controller/AdminController.java
@@ -1,0 +1,20 @@
+package emory.emoryserver.domain.admin.controller;
+
+import emory.emoryserver.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+
+    @GetMapping("/users/count")
+    public ResponseEntity<Long> countUsers() {
+        long count = userService.countAllUsers();
+        return ResponseEntity.ok(count);
+    }
+}

--- a/src/main/java/emory/emoryserver/domain/auth/controller/AuthController.java
+++ b/src/main/java/emory/emoryserver/domain/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package emory.emoryserver.domain.auth.controller;
+
+import emory.emoryserver.domain.auth.dto.request.OauthRequestDto;
+import emory.emoryserver.domain.auth.dto.response.OauthLoginResponseDto;
+import emory.emoryserver.domain.auth.service.OauthLoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final OauthLoginService oauthLoginService;
+
+    // SNS 로그인 API (Google / Kakao)
+    @PostMapping("/oauth")
+    public ResponseEntity<OauthLoginResponseDto> oauthLogin(
+            @RequestBody @Valid OauthRequestDto requestDto) {
+        OauthLoginResponseDto responseDto = oauthLoginService.login(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/emory/emoryserver/domain/auth/dto/request/OauthRequestDto.java
+++ b/src/main/java/emory/emoryserver/domain/auth/dto/request/OauthRequestDto.java
@@ -1,0 +1,19 @@
+package emory.emoryserver.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OauthRequestDto {
+
+    @Schema(description = "SNS access token", example = "ya29.a0AfH6...")
+    @NotBlank(message = "accessToken은 필수입니다.")
+    private String accessToken;
+
+    @Schema(description = "provider 이름 (google / kakao)", example = "google")
+    @NotBlank(message = "provider는 필수입니다.")
+    private String provider;
+}

--- a/src/main/java/emory/emoryserver/domain/auth/dto/response/OauthLoginResponseDto.java
+++ b/src/main/java/emory/emoryserver/domain/auth/dto/response/OauthLoginResponseDto.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OauthLoginResponseDto {
+    private String accessToken;
+    private boolean isNewUser;
+}

--- a/src/main/java/emory/emoryserver/domain/auth/service/OauthLoginService.java
+++ b/src/main/java/emory/emoryserver/domain/auth/service/OauthLoginService.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.domain.auth.service;
+
+import emory.emoryserver.domain.auth.dto.request.OauthRequestDto;
+import emory.emoryserver.domain.auth.dto.response.OauthLoginResponseDto;
+
+public interface OauthLoginService {
+    OauthLoginResponseDto login(OauthRequestDto requestDto);
+}

--- a/src/main/java/emory/emoryserver/domain/auth/service/OauthLoginServiceImpl.java
+++ b/src/main/java/emory/emoryserver/domain/auth/service/OauthLoginServiceImpl.java
@@ -1,0 +1,69 @@
+package emory.emoryserver.domain.auth.service;
+
+import emory.emoryserver.domain.auth.dto.request.OauthRequestDto;
+import emory.emoryserver.domain.auth.dto.response.OauthLoginResponseDto;
+import emory.emoryserver.domain.user.entity.User;
+import emory.emoryserver.domain.user.repository.UserRepository;
+import emory.emoryserver.global.external.oauth.GoogleOauthClient;
+import emory.emoryserver.global.external.oauth.KakaoOauthClient;
+import emory.emoryserver.global.external.oauth.dto.OauthUserInfo;
+import emory.emoryserver.global.config.auth.JwtTokenProvider;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OauthLoginServiceImpl implements OauthLoginService {
+
+    private final GoogleOauthClient googleOauthClient;
+    private final KakaoOauthClient kakaoOauthClient;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    @Transactional
+    public OauthLoginResponseDto login(OauthRequestDto requestDto) {
+        OauthUserInfo userInfo;
+
+        // 1. Provider에 따라 사용자 정보 요청
+        switch (requestDto.getProvider().toLowerCase()) {
+            case "google":
+                userInfo = googleOauthClient.getUserInfo(requestDto.getAccessToken());
+                break;
+            case "kakao":
+                userInfo = kakaoOauthClient.getUserInfo(requestDto.getAccessToken());
+                break;
+            default:
+                throw new IllegalArgumentException("지원하지 않는 로그인 제공자입니다: " + requestDto.getProvider());
+        }
+
+        // 2. 이메일 기준으로 기존 사용자 검색
+        User user = userRepository.findByEmail(userInfo.getEmail()).orElse(null);
+        boolean isNewUser = false;
+
+        // 3. 신규 사용자면 회원가입 처리
+        if (user == null) {
+            user = User.builder()
+                    .provider(requestDto.getProvider())
+                    .providerId(userInfo.getProviderId())
+                    .email(userInfo.getEmail())
+                    .nickname(userInfo.getNickname())
+                    .build();
+
+            userRepository.save(user);
+            isNewUser = true;
+        }
+
+        // 4. JWT 발급 (email을 subject로)
+        String token = jwtTokenProvider.createToken(
+                user.getEmail(),
+                List.of("ROLE_USER")
+        );
+
+        // 5. 응답 반환
+        return new OauthLoginResponseDto(token, isNewUser);
+    }
+}

--- a/src/main/java/emory/emoryserver/domain/user/controller/UserController.java
+++ b/src/main/java/emory/emoryserver/domain/user/controller/UserController.java
@@ -1,0 +1,39 @@
+package emory.emoryserver.domain.user.controller;
+
+import emory.emoryserver.domain.user.dto.request.UserProfileUpdateRequest;
+import emory.emoryserver.domain.user.dto.response.UserProfileResponse;
+import emory.emoryserver.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileResponse> getProfile(
+            @AuthenticationPrincipal String email) {
+        UserProfileResponse profile = userService.getMyProfile(email);
+        return ResponseEntity.ok(profile);
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<UserProfileResponse> updateProfile(
+            @AuthenticationPrincipal String email,
+            @RequestBody UserProfileUpdateRequest request) {
+        UserProfileResponse updated = userService.updateProfile(email, request);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/account")
+    public ResponseEntity<Void> deleteAccount(
+            @AuthenticationPrincipal String email) {
+        userService.deleteAccount(email);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/emory/emoryserver/domain/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/emory/emoryserver/domain/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,8 @@
+package emory.emoryserver.domain.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileUpdateRequest {
+    private String nickname;
+}

--- a/src/main/java/emory/emoryserver/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/emory/emoryserver/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,11 @@
+package emory.emoryserver.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileResponse {
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/emory/emoryserver/domain/user/entity/User.java
+++ b/src/main/java/emory/emoryserver/domain/user/entity/User.java
@@ -1,0 +1,38 @@
+package emory.emoryserver.domain.user.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(collection = "users")
+public class User {
+
+    @Id
+    private String id;
+
+    private String email;
+    private String password;  // SNS 로그인만 한다면 사용하지 않아도 됨
+    private String nickname;
+
+    private String provider;
+    private String providerId;
+
+    private boolean diaryReminderEnabled = false;
+    private String reminderTime = null;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateDiarySetting(boolean enabled, String time) {
+        this.diaryReminderEnabled = enabled;
+        this.reminderTime = time;
+    }
+}

--- a/src/main/java/emory/emoryserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/emory/emoryserver/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package emory.emoryserver.domain.user.repository;
+
+import emory.emoryserver.domain.user.entity.User;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import java.util.Optional;
+
+public interface UserRepository extends MongoRepository<User, String> {
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/emory/emoryserver/domain/user/service/UserService.java
+++ b/src/main/java/emory/emoryserver/domain/user/service/UserService.java
@@ -1,0 +1,12 @@
+package emory.emoryserver.domain.user.service;
+
+import emory.emoryserver.domain.user.dto.request.UserProfileUpdateRequest;
+import emory.emoryserver.domain.user.dto.response.UserProfileResponse;
+
+public interface UserService {
+    UserProfileResponse getMyProfile(String userId);
+    UserProfileResponse updateProfile(String userId, UserProfileUpdateRequest request);
+    void deleteAccount(String userId); // 회원 탈퇴
+    long countAllUsers();
+
+}

--- a/src/main/java/emory/emoryserver/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/emory/emoryserver/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,45 @@
+package emory.emoryserver.domain.user.service;
+
+import emory.emoryserver.domain.user.dto.request.UserProfileUpdateRequest;
+import emory.emoryserver.domain.user.dto.response.UserProfileResponse;
+import emory.emoryserver.domain.user.entity.User;
+import emory.emoryserver.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserProfileResponse getMyProfile(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        return new UserProfileResponse(user.getEmail(), user.getNickname());
+    }
+
+    @Override
+    public UserProfileResponse updateProfile(String email, UserProfileUpdateRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        user.updateNickname(request.getNickname());
+        userRepository.save(user);
+
+        return new UserProfileResponse(user.getEmail(), user.getNickname());
+    }
+
+    @Override
+    public void deleteAccount(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        userRepository.delete(user);
+    }
+
+    @Override
+    public long countAllUsers() {
+        return userRepository.count();
+    }
+}

--- a/src/main/java/emory/emoryserver/global/config/auth/CustomUserDetailsService.java
+++ b/src/main/java/emory/emoryserver/global/config/auth/CustomUserDetailsService.java
@@ -1,0 +1,29 @@
+package emory.emoryserver.global.config.auth;
+
+import emory.emoryserver.domain.user.entity.User;
+import emory.emoryserver.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일의 사용자를 찾을 수 없습니다: " + email));
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getEmail())
+                .password(user.getPassword()) // 이미 암호화된 비밀번호
+                .authorities("ROLE_USER")
+                .build();
+    }
+}

--- a/src/main/java/emory/emoryserver/global/config/auth/JwtAuthFilter.java
+++ b/src/main/java/emory/emoryserver/global/config/auth/JwtAuthFilter.java
@@ -1,0 +1,78 @@
+package emory.emoryserver.global.config.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final List<String> WHITELIST = List.of(            "/api/auth",
+            "/api/auth",
+            "/v3/api-docs",
+            "/swagger",
+            "/swagger-ui",
+            "/swagger-resources",
+            "/webjars",
+            "/favicon.ico"
+    );
+
+    private boolean isWhitelisted(String path) {
+        return WHITELIST.stream().anyMatch(path::contains);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        if (isWhitelisted(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String token = jwtTokenProvider.resolveToken(request);
+            System.out.println("추출된 토큰: " + token);
+
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                var authentication = jwtTokenProvider.getAuthentication(token);
+
+                if (authentication != null) {
+                    UsernamePasswordAuthenticationToken authenticationToken =
+                            (UsernamePasswordAuthenticationToken) authentication;
+
+                    System.out.println("인증 성공: " + authenticationToken.getPrincipal());
+                    authenticationToken.setDetails(
+                            new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                } else {
+                    System.out.println("authentication == null");
+                }
+            } else {
+                System.out.println("토큰 없음 or 유효하지 않음");
+            }
+        } catch (Exception e) {
+            System.out.println("필터 처리 중 예외 발생: " + e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/emory/emoryserver/global/config/auth/JwtTokenProvider.java
+++ b/src/main/java/emory/emoryserver/global/config/auth/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package emory.emoryserver.global.config.auth;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+
+    // 토큰 유효 시간: 1시간
+    private final long tokenValidTime = 1000L * 60 * 60;
+
+    // Bean 생성 후 시크릿 키 초기화
+    @PostConstruct
+    protected void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    // JWT 생성 - 이메일과 권한 리스트 포함
+    public String createToken(String email, List<String> roles) {
+        Claims claims = Jwts.claims().setSubject(email); // sub = email
+        claims.put("roles", roles); // 사용자 역할 추가
+
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + tokenValidTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // JWT로부터 인증 정보 추출
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        String email = claims.getSubject(); // sub에서 이메일 추출
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) claims.get("roles");
+
+        List<GrantedAuthority> authorities = roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // principal = email (String)
+        return new UsernamePasswordAuthenticationToken(email, "", authorities);
+    }
+
+    // JWT에서 이메일 추출
+    public String getUsername(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token).getBody().getSubject();
+    }
+
+    // JWT 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // Request 헤더에서 Authorization: Bearer <token> 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 제거
+        }
+        return null;
+    }
+}

--- a/src/main/java/emory/emoryserver/global/config/auth/SecurityConfig.java
+++ b/src/main/java/emory/emoryserver/global/config/auth/SecurityConfig.java
@@ -1,0 +1,54 @@
+package emory.emoryserver.global.config.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthFilter jwtAuthFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeHttpRequests()
+                .requestMatchers(
+                        "/api/auth/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/swagger-resources/**",
+                        "/swagger-ui.html",
+                        "/webjars/**",
+                        "/favicon.ico"
+                ).permitAll()
+                .requestMatchers("/api/user/**").hasRole("USER")
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/emory/emoryserver/global/external/oauth/GoogleOauthClient.java
+++ b/src/main/java/emory/emoryserver/global/external/oauth/GoogleOauthClient.java
@@ -1,0 +1,43 @@
+package emory.emoryserver.global.external.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import emory.emoryserver.global.external.oauth.dto.GoogleUserInfo;
+import emory.emoryserver.global.external.oauth.dto.OauthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOauthClient {
+
+    private static final String GOOGLE_USER_INFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public OauthUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                GOOGLE_USER_INFO_URL,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        try {
+            Map<String, Object> attributes = objectMapper.readValue(response.getBody(), Map.class);
+            return new GoogleUserInfo(attributes);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse Google user info", e);
+        }
+    }
+}

--- a/src/main/java/emory/emoryserver/global/external/oauth/KakaoOauthClient.java
+++ b/src/main/java/emory/emoryserver/global/external/oauth/KakaoOauthClient.java
@@ -1,0 +1,43 @@
+package emory.emoryserver.global.external.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import emory.emoryserver.global.external.oauth.dto.KakaoUserInfo;
+import emory.emoryserver.global.external.oauth.dto.OauthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOauthClient {
+
+    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public OauthUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                KAKAO_USER_INFO_URL,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        try {
+            Map<String, Object> attributes = objectMapper.readValue(response.getBody(), Map.class);
+            return new KakaoUserInfo(attributes);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse Kakao user info", e);
+        }
+    }
+}

--- a/src/main/java/emory/emoryserver/global/external/oauth/dto/GoogleUserInfo.java
+++ b/src/main/java/emory/emoryserver/global/external/oauth/dto/GoogleUserInfo.java
@@ -1,0 +1,34 @@
+package emory.emoryserver.global.external.oauth.dto;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class GoogleUserInfo implements OauthUserInfo {
+
+    private final String id;
+    private final String email;
+    private final String name;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.id = (String) attributes.get("sub");
+        this.email = (String) attributes.get("email");
+        this.name = (String) attributes.get("name");
+    }
+
+    @Override
+    public String getProviderId() {
+        return id;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getNickname() {
+        return name;
+    }
+}

--- a/src/main/java/emory/emoryserver/global/external/oauth/dto/KakaoUserInfo.java
+++ b/src/main/java/emory/emoryserver/global/external/oauth/dto/KakaoUserInfo.java
@@ -1,0 +1,38 @@
+package emory.emoryserver.global.external.oauth.dto;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class KakaoUserInfo implements OauthUserInfo {
+
+    private final String id;
+    private final String email;
+    private final String nickname;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.id = String.valueOf(attributes.get("id"));
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.email = (String) kakaoAccount.get("email");
+
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        this.nickname = (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getProviderId() {
+        return id;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/src/main/java/emory/emoryserver/global/external/oauth/dto/OauthUserInfo.java
+++ b/src/main/java/emory/emoryserver/global/external/oauth/dto/OauthUserInfo.java
@@ -1,0 +1,10 @@
+package emory.emoryserver.global.external.oauth.dto;
+
+public interface OauthUserInfo {
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getNickname();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=emoryserver
+jwt.secret=abcdefghijklmnopqrstuvwxyz123456789ABCDEFG
+jwt.expiration=3600000
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+spring.data.mongodb.uri=mongodb://localhost:27017/emory-db


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#5 Auth 및 User 기능 설계

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- Google, Kakao OAuth 로그인 로직 구현
- JWT 발급 및 필터 설정
- UserRepository, UserServiceImpl, JwtTokenProvider 등 관련 클래스 구현
- application.properties 충돌 해결

<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- application.properties 파일에서 merge conflict가 발생했는데, 큰 문제가 없어 병합 완료했습니다.
- OAuth 관련 클래스/서비스 구조가 적절한지 리뷰 부탁드립니다.

<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>
[구글 oauth 로그인](https://zoiworld.tistory.com/1054)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth login (Google, Kakao) and JWT-based authentication.
  * User profile management: view, update nickname, delete account.
  * Admin endpoint to retrieve total user count.

* **Improvements**
  * Role-based access control for user and admin APIs.
  * API documentation and Swagger UI exposed.

* **Chores**
  * Dependency and build configuration updates.
  * MongoDB added for user data storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->