### PR TITLE
fix: gcloud run delpoy traffic error latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -78,7 +78,7 @@ steps:
           --allow-unauthenticated \
           --cpu=1 --memory=512Mi \
           --cpu-boost \
-          --to-latest \
+          --traffic LATEST=100 \
           --set-env-vars=SPRING_PROFILES_ACTIVE=prod
 
 images:


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->


<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->


<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Chores
  - Updated deployment configuration to route 100% of traffic to the latest service revision on release.
  - Improves consistency and predictability during rollouts without altering build, push, or environment settings.
  - Existing services continue operating as before; deployments now automatically point users to the newest revision once released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->