### PR TITLE
Feat/#15 aidiary feedback

### DIFF
--- a/src/main/java/emory/emoryserver/aidiary/controller/FeedbackController.java
+++ b/src/main/java/emory/emoryserver/aidiary/controller/FeedbackController.java
@@ -1,34 +1,34 @@
 package emory.emoryserver.aidiary.controller;
 
 import emory.emoryserver.aidiary.dto.FeedbackSaveRequestDto;
+import emory.emoryserver.aidiary.dto.FeedbackSaveResponseDto;
+import emory.emoryserver.aidiary.service.FeedbackService;
+import emory.emoryserver.global.util.UserIdExtractor;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-@Tag(name = "Diary Feedback", description = "사용자 선택형 피드백 저장 API")
+@Tag(name = "Diary Feedback", description = "AI 일기 피드백 저장 API")
 @RestController
-@RequestMapping("/diary/feedback")
+@RequestMapping("/aidiary/diary")
+@RequiredArgsConstructor
 public class FeedbackController {
 
-    @Operation(summary = "피드백 항목 목록 조회", description = "사용자가 선택할 수 있는 피드백 항목 목록 반환합니다.")
-    @GetMapping("/options")
-    public ResponseEntity<List<String>> getFeedbackOptions() {
-        List<String> options = List.of(
-                "내 감정과 하루를 잘 반영했어요",
-                "내 감정과 하루를 잘 반영하지 못했어요",
-                "문맥이 이상해요",
-                "말투가 어색해요"
-        );
-        return ResponseEntity.ok(options);
-    }
+    private final FeedbackService feedbackService;
+    private final UserIdExtractor userIdExtractor;
 
-    @Operation(summary = "일기 선택형 피드백 저장", description = "사용자가 AI 일기에 대한 피드백을 선택하고 저장합니다.")
-    @PostMapping("/{diaryId}")
-    public void saveFeedback(@PathVariable Long DiaryId,
-                             @RequestBody FeedbackSaveRequestDto request) {
-        //선택형 피드백 저장 로직
+    @Operation(summary = "일기 피드백 저장/업데이트", description = "선택형 피드백을 저장합니다. 동일 diary에 재요청 시 업데이트됩니다.")
+    @PostMapping("/{diaryId}/feedback")
+    public FeedbackSaveResponseDto saveFeedback(
+            @PathVariable String diaryId,
+            @AuthenticationPrincipal String email,
+            @Valid @RequestBody FeedbackSaveRequestDto request
+    ) {
+        String userId = userIdExtractor.getUserIdFromEmail(email);
+        return feedbackService.saveOrUpdate(diaryId, userId, request);
     }
 }
+

--- a/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveRequestDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveRequestDto.java
@@ -1,10 +1,12 @@
 package emory.emoryserver.aidiary.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
 public class FeedbackSaveRequestDto {
+    @NotBlank
     @Schema(description = "선택한 피드백 항목", example = "말투가 어색해요")
     private String selectedOption;
 }

--- a/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveResponseDto.java
+++ b/src/main/java/emory/emoryserver/aidiary/dto/FeedbackSaveResponseDto.java
@@ -1,0 +1,16 @@
+package emory.emoryserver.aidiary.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class FeedbackSaveResponseDto {
+    private String feedbackId;
+    private String diaryId;
+    private String selectedOption;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/emory/emoryserver/aidiary/model/AiDiaryFeedback.java
+++ b/src/main/java/emory/emoryserver/aidiary/model/AiDiaryFeedback.java
@@ -1,0 +1,24 @@
+package emory.emoryserver.aidiary.model;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Document("diary_feedbacks")
+public class AiDiaryFeedback {
+
+    @Id
+    private String id;
+
+    private String diaryId;        // AiDiary._id (ObjectId string)
+    private String userId;         // 내부 userId
+
+    private String selectedOption; // "말투가 어색해요" 같은 선택형 피드백
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/emory/emoryserver/aidiary/repository/AiDiaryFeedbackRepository.java
+++ b/src/main/java/emory/emoryserver/aidiary/repository/AiDiaryFeedbackRepository.java
@@ -1,0 +1,10 @@
+package emory.emoryserver.aidiary.repository;
+
+import emory.emoryserver.aidiary.model.AiDiaryFeedback;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface AiDiaryFeedbackRepository extends MongoRepository<AiDiaryFeedback, String> {
+    Optional<AiDiaryFeedback> findByDiaryIdAndUserId(String diaryId, String userId);
+}

--- a/src/main/java/emory/emoryserver/aidiary/service/FeedbackService.java
+++ b/src/main/java/emory/emoryserver/aidiary/service/FeedbackService.java
@@ -1,0 +1,57 @@
+package emory.emoryserver.aidiary.service;
+
+import emory.emoryserver.aidiary.dto.FeedbackSaveRequestDto;
+import emory.emoryserver.aidiary.dto.FeedbackSaveResponseDto;
+import emory.emoryserver.aidiary.exception.DiaryNotFoundException;
+import emory.emoryserver.aidiary.model.AiDiaryFeedback;
+import emory.emoryserver.aidiary.repository.AiDiaryFeedbackRepository;
+import emory.emoryserver.aidiary.repository.AiDiaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+
+    private final AiDiaryRepository aiDiaryRepository;
+    private final AiDiaryFeedbackRepository feedbackRepository;
+
+    public FeedbackSaveResponseDto saveOrUpdate(String diaryId, String userId, FeedbackSaveRequestDto req) {
+        if (diaryId == null || diaryId.isBlank()) throw new IllegalArgumentException("diaryId는 필수입니다.");
+        if (userId == null || userId.isBlank()) throw new IllegalArgumentException("userId는 필수입니다.");
+        if (req == null || req.getSelectedOption() == null || req.getSelectedOption().isBlank())
+            throw new IllegalArgumentException("selectedOption은 필수입니다.");
+
+        // ✅ 내 일기인지 확인 (owner만 피드백 저장하도록)
+        aiDiaryRepository.findByIdAndUserId(diaryId, userId)
+                .orElseThrow(() -> new DiaryNotFoundException(diaryId));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        AiDiaryFeedback saved = feedbackRepository.findByDiaryIdAndUserId(diaryId, userId)
+                .map(existing -> {
+                    existing.setSelectedOption(req.getSelectedOption());
+                    existing.setUpdatedAt(now);
+                    return feedbackRepository.save(existing);
+                })
+                .orElseGet(() -> feedbackRepository.save(
+                        AiDiaryFeedback.builder()
+                                .diaryId(diaryId)
+                                .userId(userId)
+                                .selectedOption(req.getSelectedOption())
+                                .createdAt(now)
+                                .updatedAt(now)
+                                .build()
+                ));
+
+        return FeedbackSaveResponseDto.builder()
+                .feedbackId(saved.getId())
+                .diaryId(saved.getDiaryId())
+                .selectedOption(saved.getSelectedOption())
+                .createdAt(saved.getCreatedAt())
+                .updatedAt(saved.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#15 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- `POST /aidiary/diary/{diaryId}/feedback` 
- Request Body: { "selectedOption": "..." }
- Response: feedbackId, diaryId, selectedOption, createdAt, updatedAt 반환
- 저장 시 userId는 @AuthenticationPrincipal(email) → UserIdExtractor로 추출하여 저장

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Consolidated feedback save/update endpoint for AI diary entries, now requiring user authentication for secure operations.
  * Added validation for feedback selections to ensure data quality and consistency.

* **Improvements**
  * Enhanced response structure for feedback operations, including detailed metadata with creation and update timestamps for better tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->