### PR TITLE
Feat/#14 emotion analyze

### DIFF
--- a/src/main/java/emory/emoryserver/EmoryserverApplication.java
+++ b/src/main/java/emory/emoryserver/EmoryserverApplication.java
@@ -9,7 +9,8 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 		"emory.emoryserver.aidiary.repository",
 		"emory.emoryserver.ai.repository",
 		"emory.emoryserver.calendar.repository",
-		"emory.emoryserver.domain.user.repository"
+		"emory.emoryserver.domain.user.repository",
+		"emory.emoryserver.report.repository"
 })
 public class EmoryserverApplication {
 

--- a/src/main/java/emory/emoryserver/ai/repository/ChatLogRepository.java
+++ b/src/main/java/emory/emoryserver/ai/repository/ChatLogRepository.java
@@ -4,6 +4,7 @@ import emory.emoryserver.ai.model.ChatLog;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -12,4 +13,10 @@ public interface ChatLogRepository extends MongoRepository<ChatLog, String> {
 
     // 세션만 기준 (필요 시)
     List<ChatLog> findBySessionIdOrderByCreatedAtAsc(String sessionId);
+
+    List<ChatLog> findByUserIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+            String userId,
+            LocalDateTime start,
+            LocalDateTime end
+    );
 }

--- a/src/main/java/emory/emoryserver/ai/service/ChatSessionService.java
+++ b/src/main/java/emory/emoryserver/ai/service/ChatSessionService.java
@@ -6,11 +6,13 @@ import emory.emoryserver.ai.model.ChatLog;
 import emory.emoryserver.ai.model.ChatSession;
 import emory.emoryserver.ai.repository.ChatLogRepository;
 import emory.emoryserver.ai.repository.ChatSessionRepository;
+import emory.emoryserver.report.service.DailyReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +24,7 @@ public class ChatSessionService {
 
     private final ChatSessionRepository chatSessionRepository;
     private final ChatLogRepository chatLogRepository;
+    private final DailyReportService dailyReportService;
 
     public String startSession(String selectedEmotion, String calendarSummary) {
         String userId = currentUserId();
@@ -79,6 +82,17 @@ public class ChatSessionService {
 
         // TODO: 여기서 후처리 트리거 (감정분석/일기생성) 붙이면 됨
         // ex) aidiary generate 호출용 이벤트 발행/큐 enqueue 등
+        try {
+            LocalDate date = session.getEndedAt().toLocalDate();
+            List<ChatLog> fullLogs = chatLogRepository.findBySessionIdAndUserIdOrderByCreatedAtAsc(
+                    session.getId(),
+                    session.getUserId()
+            );
+
+            dailyReportService.createOrUpdateDailyReportFromSession(session.getUserId(), date, fullLogs);
+        } catch (Exception e) {
+            // 리포트 생성 실패해도 대화 저장은 성공해야 함
+        }
     }
 
     public ChatSession getOwnedSessionOrThrow(String sessionId) {

--- a/src/main/java/emory/emoryserver/global/config/auth/SecurityConfig.java
+++ b/src/main/java/emory/emoryserver/global/config/auth/SecurityConfig.java
@@ -98,7 +98,8 @@ public class SecurityConfig {
                         .requestMatchers("/diary/**").authenticated()
                         .requestMatchers("/calendar/**").authenticated()
                         .requestMatchers("/timecapsule/**").authenticated()
-                        .requestMatchers("/report/**").authenticated()
+                        .requestMatchers("/report/**").permitAll()
+                        .requestMatchers("/ai/**").permitAll()
                         .requestMatchers("/api/user/**", "/api/admin/**").authenticated()
 
                         // 나머지 전부 보호

--- a/src/main/java/emory/emoryserver/report/controller/ReportController.java
+++ b/src/main/java/emory/emoryserver/report/controller/ReportController.java
@@ -1,6 +1,7 @@
 package emory.emoryserver.report.controller;
 
 import emory.emoryserver.report.dto.ReportResponseDto;
+import emory.emoryserver.report.service.DailyReportService;
 import emory.emoryserver.report.service.ReportService;
 import emory.emoryserver.global.util.UserIdExtractor;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,18 @@ public class ReportController {
 
     private final ReportService reportService;
     private final UserIdExtractor userIdExtractor;
+    private final DailyReportService dailyReportService;
+
+    @Operation(summary = "하루 감정 리포트", description = "대화 transcript 기반 감정 분포 + AI 피드백")
+    @GetMapping("/daily/{date}")
+    public ReportResponseDto getDailyReport(
+            @Parameter(description = "기준 날짜 (YYYY-MM-DD)")
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal String email
+    ) {
+        String userId = userIdExtractor.getUserIdFromEmail(email);
+        return dailyReportService.getDailyReport(userId, date);
+    }
 
     @Operation(summary = "주간 감정 리포트", description = "일요일부터 토요일 기준, 감정별 통계")
     @GetMapping("/weekly/{date}")

--- a/src/main/java/emory/emoryserver/report/dto/DailyReportResponseDto.java
+++ b/src/main/java/emory/emoryserver/report/dto/DailyReportResponseDto.java
@@ -1,0 +1,16 @@
+package emory.emoryserver.report.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public class DailyReportResponseDto {
+    private LocalDate date;
+    private String dominantEmotion;
+    private Map<String, Double> emotionDistribution; // 합 100
+    private List<EmotionStatDto> emotionStats;
+    private String aiFeedback;
+}

--- a/src/main/java/emory/emoryserver/report/model/DailyEmotionReport.java
+++ b/src/main/java/emory/emoryserver/report/model/DailyEmotionReport.java
@@ -1,0 +1,40 @@
+package emory.emoryserver.report.model;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document("daily_emotion_reports")
+public class DailyEmotionReport {
+
+    @Id
+    private String id;
+
+    private String userId;
+    private LocalDate date;
+
+    /**
+     * 감정 분포(합 100) - key는 감정 라벨(예: HAPPY, SAD...)
+     */
+    private Map<String, Double> emotionDistribution;
+
+    private String dominantEmotion;
+
+    /**
+     * 감정 분포 + 대화내용 기반 AI 피드백 (report 폴더 로직 재사용)
+     */
+    private String aiFeedback;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/emory/emoryserver/report/repository/DailyEmotionReportRepository.java
+++ b/src/main/java/emory/emoryserver/report/repository/DailyEmotionReportRepository.java
@@ -1,0 +1,13 @@
+package emory.emoryserver.report.repository;
+
+import emory.emoryserver.report.model.DailyEmotionReport;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface DailyEmotionReportRepository extends MongoRepository<DailyEmotionReport, String> {
+    Optional<DailyEmotionReport> findByUserIdAndDate(String userId, LocalDate date);
+}

--- a/src/main/java/emory/emoryserver/report/service/DailyReportService.java
+++ b/src/main/java/emory/emoryserver/report/service/DailyReportService.java
@@ -1,0 +1,173 @@
+package emory.emoryserver.report.service;
+
+import emory.emoryserver.ai.model.ChatLog;
+import emory.emoryserver.ai.repository.ChatLogRepository;
+import emory.emoryserver.report.dto.EmotionStatDto;
+import emory.emoryserver.report.dto.ReportResponseDto;
+import emory.emoryserver.report.model.DailyEmotionReport;
+import emory.emoryserver.report.repository.DailyEmotionReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DailyReportService {
+
+    private final DailyEmotionReportRepository dailyEmotionReportRepository;
+    private final ChatLogRepository chatLogRepository;
+    private final OpenAIEmotionService openAIEmotionService;
+    private final OpenAIReportService openAIReportService;
+
+    /**
+     * GET /report/daily/{date}
+     * - 저장된 daily report 있으면 그대로 반환
+     * - 없으면 해당 날짜 chat_messages 기반으로 생성 시도 후 저장/반환
+     */
+    public ReportResponseDto getDailyReport(String userId, LocalDate date) {
+        Optional<DailyEmotionReport> saved = dailyEmotionReportRepository.findByUserIdAndDate(userId, date);
+        if (saved.isPresent()) {
+            return toResponse(saved.get());
+        }
+
+        // fallback: 해당 날짜의 chat_messages(userId 기준)로 생성
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.plusDays(1).atStartOfDay().minusNanos(1);
+
+        List<ChatLog> logs = chatLogRepository.findByUserIdAndCreatedAtBetweenOrderByCreatedAtAsc(userId, start, end);
+        if (logs == null || logs.isEmpty()) {
+            return ReportResponseDto.builder()
+                    .periodStart(date)
+                    .periodEnd(date)
+                    .reportType("DAILY")
+                    .emotionStats(List.of())
+                    .totalDiaryCount(0)
+                    .dominantEmotion(null)
+                    .aiFeedback(null)
+                    .build();
+        }
+
+        DailyEmotionReport created = createAndSaveDailyReport(userId, date, logs);
+        return toResponse(created);
+    }
+
+    /**
+     * saveConversation 후처리 트리거용
+     * - 전달받은 logs(세션 전체 로그)로 daily report 업서트
+     */
+    public void createOrUpdateDailyReportFromSession(String userId, LocalDate date, List<ChatLog> logs) {
+        if (logs == null || logs.isEmpty()) return;
+
+        Optional<DailyEmotionReport> existing = dailyEmotionReportRepository.findByUserIdAndDate(userId, date);
+
+        DailyEmotionReport created = createDailyReportObject(userId, date, logs);
+
+        if (existing.isPresent()) {
+            DailyEmotionReport e = existing.get();
+            e.setEmotionDistribution(created.getEmotionDistribution());
+            e.setDominantEmotion(created.getDominantEmotion());
+            e.setAiFeedback(created.getAiFeedback());
+            e.setUpdatedAt(LocalDateTime.now());
+            dailyEmotionReportRepository.save(e);
+        } else {
+            created.setCreatedAt(LocalDateTime.now());
+            created.setUpdatedAt(LocalDateTime.now());
+            dailyEmotionReportRepository.save(created);
+        }
+    }
+
+    private DailyEmotionReport createAndSaveDailyReport(String userId, LocalDate date, List<ChatLog> logs) {
+        DailyEmotionReport created = createDailyReportObject(userId, date, logs);
+        created.setCreatedAt(LocalDateTime.now());
+        created.setUpdatedAt(LocalDateTime.now());
+        return dailyEmotionReportRepository.save(created);
+    }
+
+    private DailyEmotionReport createDailyReportObject(String userId, LocalDate date, List<ChatLog> logs) {
+        // 1) OpenAI로 감정 분포 얻기 (합 100)
+        Map<String, Double> dist = openAIEmotionService.analyzeDistribution(logs);
+
+        // 2) dist -> emotionStats (응답에 필요)
+        List<EmotionStatDto> emotionStats = toEmotionStats(dist);
+        String dominantEmotion = emotionStats.isEmpty() ? null : emotionStats.get(0).getEmotion();
+
+        // 3) 피드백 입력 snippets (user 발화 일부)
+        List<String> snippets = buildSnippets(logs);
+
+        // 4) 이미 구현된 report 폴더의 OpenAIReportService 재사용
+        String aiFeedback;
+        try {
+            aiFeedback = openAIReportService.generateFeedback(dominantEmotion, emotionStats, snippets);
+            if (aiFeedback != null && aiFeedback.isBlank()) aiFeedback = null;
+        } catch (Exception e) {
+            aiFeedback = null;
+        }
+
+        return DailyEmotionReport.builder()
+                .userId(userId)
+                .date(date)
+                .emotionDistribution(dist)
+                .dominantEmotion(dominantEmotion)
+                .aiFeedback(aiFeedback)
+                .build();
+    }
+
+    private List<EmotionStatDto> toEmotionStats(Map<String, Double> dist) {
+        if (dist == null || dist.isEmpty()) return List.of();
+
+        return dist.entrySet().stream()
+                .map(e -> {
+                    double pct = e.getValue() == null ? 0.0 : e.getValue();
+                    pct = Math.round(pct * 100.0) / 100.0; // 소수점 2자리
+                    return EmotionStatDto.builder()
+                            .emotion(e.getKey())
+                            .count((int) Math.round(pct)) // %를 정수로 넣음(프론트에서 count 안 써도 됨)
+                            .percentage(pct)
+                            .build();
+                })
+                .sorted((a, b) -> Double.compare(
+                        b.getPercentage() == null ? 0.0 : b.getPercentage(),
+                        a.getPercentage() == null ? 0.0 : a.getPercentage()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private List<String> buildSnippets(List<ChatLog> logs) {
+        if (logs == null) return List.of();
+
+        List<String> userTexts = new ArrayList<>();
+        for (ChatLog log : logs) {
+            if (log == null) continue;
+            String role = log.getRole() == null ? "" : log.getRole().trim().toLowerCase();
+            String text = log.getText() == null ? "" : log.getText().trim();
+            if (!"user".equals(role)) continue;
+            if (text.isBlank()) continue;
+
+            if (text.length() > 300) text = text.substring(0, 300) + "…";
+            userTexts.add(text);
+
+            if (userTexts.size() >= 3) break;
+        }
+        return userTexts;
+    }
+
+    private ReportResponseDto toResponse(DailyEmotionReport report) {
+        List<EmotionStatDto> emotionStats = toEmotionStats(report.getEmotionDistribution());
+
+        return ReportResponseDto.builder()
+                .periodStart(report.getDate())
+                .periodEnd(report.getDate())
+                .reportType("DAILY")
+                .emotionStats(emotionStats)
+                // daily는 “그날 리포트 1개 존재” 의미로 1, 없으면 0이 자연스러움
+                .totalDiaryCount(1)
+                .dominantEmotion(report.getDominantEmotion())
+                .aiFeedback(report.getAiFeedback())
+                .build();
+    }
+}
+

--- a/src/main/java/emory/emoryserver/report/service/OpenAIEmotionService.java
+++ b/src/main/java/emory/emoryserver/report/service/OpenAIEmotionService.java
@@ -1,0 +1,323 @@
+package emory.emoryserver.report.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import emory.emoryserver.ai.model.ChatLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class OpenAIEmotionService {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    // report 설정 재사용
+    @Value("${openai.report.base-url:https://api.openai.com}")
+    private String baseUrl;
+
+    @Value("${openai.report.model:gpt-5}")
+    private String model;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 프론트 emotion-report.tsx 매핑과 맞추기 위해 다음 6개 카테고리만 반환:
+     * HAPPY, SOSO, SAD, ANGRY, ANXIOUS, THOUGHTFUL
+     *
+     * @return Map<감정, 퍼센트(합100)>
+     */
+    public Map<String, Double> analyzeDistribution(List<ChatLog> logs) {
+        String transcript = buildTranscriptForAnalysis(logs);
+
+        // ✅ 디버그: 설정값 확인
+        System.out.println("[EMORY][Emotion] baseUrl=" + baseUrl + ", model=" + model
+                + ", apiKey=" + (openaiApiKey == null ? "null" : ("len=" + openaiApiKey.length())));
+
+        WebClient wc = WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + openaiApiKey)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        // ✅ JSON만 강제
+        String instructions = """
+너는 사용자의 대화 transcript를 보고 '하루 감정 분포'를 추정한다.
+
+반드시 아래 JSON 스키마를 '그대로' 출력해야 한다.
+다른 글/설명/코드블록/마크다운을 절대 포함하지 마라.
+
+{"distribution":{"HAPPY":0,"SOSO":0,"SAD":0,"ANGRY":0,"ANXIOUS":0,"THOUGHTFUL":0}}
+
+규칙:
+- 키는 정확히 6개만 사용: HAPPY, SOSO, SAD, ANGRY, ANXIOUS, THOUGHTFUL
+- 값은 0~100 숫자(실수 가능)
+- 합은 정확히 100
+- 사용자가 말하지 않은 사건/사실을 만들지 마라.
+""";
+
+        String input = """
+[대화 transcript]
+%s
+""".formatted(transcript);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", model);
+        body.put("instructions", instructions);
+        body.put("input", input);
+
+        // ✅ 핵심: reasoning을 줄여서 텍스트(JSON) 출력이 나오게 함
+        body.put("reasoning", Map.of("effort", "minimal"));
+
+        body.put("max_output_tokens", 800);
+        body.put("truncation", "auto");
+
+        // ✅ gpt-5에서 temperature 미지원 -> 절대 넣지 말기 (지금 400 원인)
+        // body.put("temperature", 0.2);
+
+        // ✅ JSON 안정성: text.format을 json_schema로 강제 (Responses API 지원)  :contentReference[oaicite:1]{index=1}
+        body.put("text", Map.of(
+                "format", Map.of(
+                        "type", "json_schema",
+                        "name", "emotion_distribution",
+                        "description", "A distribution of daily emotions that sums to 100.",
+                        "strict", true,
+                        "schema", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "required", List.of("distribution"),
+                                "properties", Map.of(
+                                        "distribution", Map.of(
+                                                "type", "object",
+                                                "additionalProperties", false,
+                                                "required", List.of("HAPPY", "SOSO", "SAD", "ANGRY", "ANXIOUS", "THOUGHTFUL"),
+                                                "properties", Map.of(
+                                                        "HAPPY", Map.of("type", "number", "minimum", 0, "maximum", 100),
+                                                        "SOSO", Map.of("type", "number", "minimum", 0, "maximum", 100),
+                                                        "SAD", Map.of("type", "number", "minimum", 0, "maximum", 100),
+                                                        "ANGRY", Map.of("type", "number", "minimum", 0, "maximum", 100),
+                                                        "ANXIOUS", Map.of("type", "number", "minimum", 0, "maximum", 100),
+                                                        "THOUGHTFUL", Map.of("type", "number", "minimum", 0, "maximum", 100)
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ));
+
+        Map resp;
+        try {
+            resp = wc.post()
+                    .uri("/v1/responses")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(Map.class)
+                    .block();
+
+            // ✅ 여기! 네가 붙여넣은 catch는 "이 try 블록 바로 아래"에 들어가면 됨
+        } catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
+            System.out.println("[EMORY][Emotion] OpenAI request FAILED: " + e.getRawStatusCode());
+            System.out.println("[EMORY][Emotion] errorBody=" + e.getResponseBodyAsString());
+            e.printStackTrace();
+            return defaultDist();
+        } catch (Exception e) {
+            System.out.println("[EMORY][Emotion] OpenAI request FAILED");
+            e.printStackTrace();
+            return defaultDist();
+        }
+
+        // ✅ 디버그: 원문 응답 확인
+        System.out.println("[EMORY][Emotion] rawResp=" + safeToString(resp));
+
+        // ✅ status가 incomplete면 fallback (중요)
+        String status = (resp == null) ? null : String.valueOf(resp.get("status"));
+        if (status != null && !"completed".equalsIgnoreCase(status)) {
+            System.out.println("[EMORY][Emotion] status not completed => fallback. status=" + status);
+            return defaultDist();
+        }
+
+        String outText = extractOutputText(resp);
+        System.out.println("[EMORY][Emotion] outText=" + outText);
+
+        // ✅ outText가 빈 경우 rawResp 상태도 찍고 fallback (중요)
+        if (outText == null || outText.trim().isEmpty()) {
+            System.out.println("[EMORY][Emotion] outText empty => fallback. status=" + status);
+            System.out.println("[EMORY][Emotion] rawResp(again)=" + safeToString(resp));
+            return defaultDist();
+        }
+
+        Map<String, Double> dist = parseDistribution(outText);
+        return normalizeTo100(dist);
+    }
+
+    private String buildTranscriptForAnalysis(List<ChatLog> logs) {
+        if (logs == null || logs.isEmpty()) return "-";
+
+        StringBuilder sb = new StringBuilder();
+        int maxChars = 5000;
+
+        for (ChatLog log : logs) {
+            if (log == null) continue;
+            String role = log.getRole() == null ? "" : log.getRole().trim().toLowerCase();
+            String text = log.getText() == null ? "" : log.getText().trim();
+            if (text.isBlank()) continue;
+
+            if ("user".equals(role)) {
+                sb.append("USER: ").append(text).append("\n");
+            } else if ("assistant".equals(role)) {
+                String cut = text.length() > 120 ? text.substring(0, 120) + "…" : text;
+                sb.append("ASSISTANT: ").append(cut).append("\n");
+            }
+
+            if (sb.length() >= maxChars) break;
+        }
+
+        String result = sb.toString().trim();
+        return result.isBlank() ? "-" : result;
+    }
+
+    private Map<String, Double> parseDistribution(String outText) {
+        try {
+            if (outText == null) return defaultDist();
+            String trimmed = outText.trim();
+            if (trimmed.isEmpty()) return defaultDist();
+
+            // ✅ 혹시 JSON 앞뒤에 잡텍스트 붙으면 { ... }만 잘라내기
+            String json = trimToJsonObject(trimmed);
+
+            Map<String, Object> root = objectMapper.readValue(json, Map.class);
+            Object d = root.get("distribution");
+            if (!(d instanceof Map<?, ?> m)) {
+                System.out.println("[EMORY][Emotion] distribution missing in JSON");
+                return defaultDist();
+            }
+
+            Map<String, Double> dist = new HashMap<>();
+            dist.put("HAPPY", toDouble(m.get("HAPPY")));
+            dist.put("SOSO", toDouble(m.get("SOSO")));
+            dist.put("SAD", toDouble(m.get("SAD")));
+            dist.put("ANGRY", toDouble(m.get("ANGRY")));
+            dist.put("ANXIOUS", toDouble(m.get("ANXIOUS")));
+            dist.put("THOUGHTFUL", toDouble(m.get("THOUGHTFUL")));
+
+            // ✅ 누락 키 방어
+            for (String k : List.of("HAPPY", "SOSO", "SAD", "ANGRY", "ANXIOUS", "THOUGHTFUL")) {
+                dist.putIfAbsent(k, 0.0);
+            }
+
+            return dist;
+        } catch (Exception e) {
+            System.out.println("[EMORY][Emotion] parseDistribution FAILED");
+            e.printStackTrace();
+            return defaultDist();
+        }
+    }
+
+    private String trimToJsonObject(String s) {
+        int start = s.indexOf('{');
+        int end = s.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            return s.substring(start, end + 1);
+        }
+        return s;
+    }
+
+    private Map<String, Double> defaultDist() {
+        Map<String, Double> m = new LinkedHashMap<>();
+        m.put("HAPPY", 16.67);
+        m.put("SOSO", 16.67);
+        m.put("SAD", 16.67);
+        m.put("ANGRY", 16.67);
+        m.put("ANXIOUS", 16.66);
+        m.put("THOUGHTFUL", 16.66);
+        return m;
+    }
+
+    private double toDouble(Object o) {
+        if (o == null) return 0.0;
+        if (o instanceof Number n) return n.doubleValue();
+        try {
+            return Double.parseDouble(String.valueOf(o));
+        } catch (Exception e) {
+            return 0.0;
+        }
+    }
+
+    private Map<String, Double> normalizeTo100(Map<String, Double> dist) {
+        if (dist == null || dist.isEmpty()) return defaultDist();
+
+        for (String k : dist.keySet()) {
+            Double v = dist.get(k);
+            if (v == null || v < 0) dist.put(k, 0.0);
+        }
+
+        double sum = dist.values().stream().mapToDouble(Double::doubleValue).sum();
+        if (sum <= 0.000001) return defaultDist();
+
+        Map<String, Double> norm = new LinkedHashMap<>();
+        double acc = 0.0;
+        List<String> keys = List.of("HAPPY", "SOSO", "SAD", "ANGRY", "ANXIOUS", "THOUGHTFUL");
+        for (String k : keys) {
+            double raw = dist.getOrDefault(k, 0.0);
+            double v = (raw / sum) * 100.0;
+            v = Math.round(v * 100.0) / 100.0;
+            norm.put(k, v);
+            acc += v;
+        }
+
+        double diff = Math.round((100.0 - acc) * 100.0) / 100.0;
+        String lastKey = "THOUGHTFUL";
+        norm.put(lastKey, Math.round((norm.get(lastKey) + diff) * 100.0) / 100.0);
+
+        return norm;
+    }
+
+    /**
+     * ✅ Responses API 응답에서 텍스트를 최대한 뽑아오기(유연)
+     */
+    private String extractOutputText(Map resp) {
+        if (resp == null) return "";
+
+        Object direct = resp.get("output_text");
+        if (direct != null) {
+            String s = String.valueOf(direct).trim();
+            if (!s.isEmpty()) return s;
+        }
+
+        Object outputObj = resp.get("output");
+        if (!(outputObj instanceof List<?> output)) return "";
+
+        StringBuilder sb = new StringBuilder();
+        for (Object item : output) {
+            if (!(item instanceof Map<?, ?> m)) continue;
+
+            Object contentObj = m.get("content");
+            if (!(contentObj instanceof List<?> parts)) continue;
+
+            for (Object p : parts) {
+                if (!(p instanceof Map<?, ?> pm)) continue;
+
+                Object text = pm.get("text");
+                if (text != null) sb.append(text);
+
+                Object value = pm.get("value");
+                if (value != null) sb.append(value);
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    private String safeToString(Object o) {
+        try {
+            return String.valueOf(o);
+        } catch (Exception e) {
+            return "<toString failed>";
+        }
+    }
+}

--- a/src/main/java/emory/emoryserver/report/service/OpenAIReportService.java
+++ b/src/main/java/emory/emoryserver/report/service/OpenAIReportService.java
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,10 +20,11 @@ public class OpenAIReportService {
     @Value("${openai.api.key}")
     private String openaiApiKey;
 
-    @Value("${openai.report.base-url}")
+    // emotion 서비스랑 동일하게 기본값 두는 걸 추천(없으면 자동으로 api.openai.com)
+    @Value("${openai.report.base-url:https://api.openai.com}")
     private String baseUrl;
 
-    @Value("${openai.report.model}")
+    @Value("${openai.report.model:gpt-5}")
     private String reportModel;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -34,6 +36,10 @@ public class OpenAIReportService {
                                    List<EmotionStatDto> emotionStats,
                                    List<String> snippets) {
 
+        // ✅ 디버그: 설정값 확인
+        System.out.println("[EMORY][Report] baseUrl=" + baseUrl + ", model=" + reportModel
+                + ", apiKey=" + (openaiApiKey == null ? "null" : ("len=" + openaiApiKey.length())));
+
         WebClient wc = WebClient.builder()
                 .baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + openaiApiKey)
@@ -43,7 +49,7 @@ public class OpenAIReportService {
         String instructions = """
 너는 사용자의 감정 리포트를 보고 공감과 실천 가능한 제안을 해주는 도우미다.
 
-반드시 JSON만 출력해라(코드블록 금지). 스키마:
+반드시 JSON만 출력해라(코드블록/마크다운/설명 금지). 스키마:
 {"feedback":"..."}
 
 규칙:
@@ -67,39 +73,90 @@ public class OpenAIReportService {
                 String.join("\n---\n", (snippets == null) ? List.of() : snippets)
         );
 
-        Map<String, Object> body = Map.of(
-                "model", reportModel,
-                "instructions", instructions,
-                "input", input,
-                "max_output_tokens", 600,
-                "truncation", "auto"
-        );
+        // ✅ Responses API body 구성 (json_schema로 JSON 강제)
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", reportModel);
+        body.put("instructions", instructions);
+        body.put("input", input);
+        body.put("reasoning", Map.of("effort", "minimal"));
+        body.put("max_output_tokens", 600);
+        body.put("truncation", "auto");
 
-        Map resp = wc.post()
-                .uri("/v1/responses")
-                .bodyValue(body)
-                .retrieve()
-                .bodyToMono(Map.class)
-                .block();
+        // ✅ JSON 스키마 강제 (프롬프트에 이상한 텍스트 끼어드는 것 방지)
+        body.put("text", Map.of(
+                "format", Map.of(
+                        "type", "json_schema",
+                        "name", "daily_feedback",
+                        "strict", true,
+                        "schema", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "properties", Map.of(
+                                        "feedback", Map.of("type", "string")
+                                ),
+                                "required", List.of("feedback")
+                        )
+                )
+        ));
+
+        Map resp;
+        try {
+            resp = wc.post()
+                    .uri("/v1/responses")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(Map.class)
+                    .block();
+        } catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
+            System.out.println("[EMORY][Report] OpenAI feedback request FAILED: " + e.getRawStatusCode());
+            System.out.println("[EMORY][Report] errorBody=" + e.getResponseBodyAsString());
+            e.printStackTrace();
+            return defaultFeedback(dominantEmotion);
+        } catch (Exception e) {
+            System.out.println("[EMORY][Report] OpenAI feedback request FAILED");
+            e.printStackTrace();
+            return defaultFeedback(dominantEmotion);
+        }
+
+        // ✅ 디버그: 원문 응답 확인
+        System.out.println("[EMORY][Report] rawResp=" + safeToString(resp));
 
         String outText = extractOutputText(resp);
+        System.out.println("[EMORY][Report] outText=" + outText);
+
+        // ✅ 핵심 방어: outText 비면 status 찍고 fallback
+        if (outText == null || outText.trim().isEmpty()) {
+            Object status = (resp == null ? null : resp.get("status"));
+            System.out.println("[EMORY][Report] feedback outText empty -> fallback. status=" + status);
+            return defaultFeedback(dominantEmotion);
+        }
 
         try {
-            Map<String, Object> json = objectMapper.readValue(outText, Map.class);
+            // outText는 {"feedback":"..."} 형태일 것으로 기대
+            String jsonOnly = trimToJsonObject(outText.trim());
+            Map<String, Object> json = objectMapper.readValue(jsonOnly, Map.class);
             Object fb = json.get("feedback");
-            return fb == null ? "" : String.valueOf(fb);
+            String fbText = (fb == null) ? "" : String.valueOf(fb).trim();
+            return fbText.isEmpty() ? defaultFeedback(dominantEmotion) : fbText;
         } catch (Exception e) {
-            // 파싱 실패 시 그냥 텍스트 반환(프론트에서라도 표시 가능)
-            return outText == null ? "" : outText;
+            // 파싱 실패 시 fallback (프론트에 null 안 뜨게)
+            System.out.println("[EMORY][Report] parse feedback FAILED -> fallback");
+            e.printStackTrace();
+            return defaultFeedback(dominantEmotion);
         }
     }
 
+    /**
+     * ✅ Responses API 응답에서 텍스트를 최대한 뽑아오기(유연)
+     */
     private String extractOutputText(Map resp) {
         if (resp == null) return "";
 
-        // responses API는 output_text를 바로 줄 수도 있음
         Object direct = resp.get("output_text");
-        if (direct != null) return String.valueOf(direct);
+        if (direct != null) {
+            String s = String.valueOf(direct).trim();
+            if (!s.isEmpty()) return s;
+        }
 
         Object outputObj = resp.get("output");
         if (!(outputObj instanceof List<?> output)) return "";
@@ -107,19 +164,30 @@ public class OpenAIReportService {
         StringBuilder sb = new StringBuilder();
         for (Object item : output) {
             if (!(item instanceof Map<?, ?> m)) continue;
-            if (!"message".equals(String.valueOf(m.get("type")))) continue;
 
             Object contentObj = m.get("content");
             if (!(contentObj instanceof List<?> parts)) continue;
 
             for (Object p : parts) {
                 if (!(p instanceof Map<?, ?> pm)) continue;
-                if ("output_text".equals(String.valueOf(pm.get("type"))) && pm.get("text") != null) {
-                    sb.append(pm.get("text"));
-                }
+
+                Object text = pm.get("text");
+                if (text != null) sb.append(text);
+
+                Object value = pm.get("value");
+                if (value != null) sb.append(value);
             }
         }
         return sb.toString().trim();
+    }
+
+    private String trimToJsonObject(String s) {
+        int start = s.indexOf('{');
+        int end = s.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            return s.substring(start, end + 1);
+        }
+        return s;
     }
 
     private String safe(String s) {
@@ -131,6 +199,22 @@ public class OpenAIReportService {
             return objectMapper.writeValueAsString(o);
         } catch (Exception e) {
             return String.valueOf(o);
+        }
+    }
+
+    private String defaultFeedback(String dominantEmotion) {
+        String emo = (dominantEmotion == null || dominantEmotion.isBlank()) ? "오늘" : dominantEmotion;
+        return "오늘은 " + emo + " 감정이 특히 두드러진 하루였네요. "
+                + "그만큼 마음이 많이 바빴을 수 있어요. "
+                + "지금 할 수 있는 작은 것부터 해보면 좋아요: 물 한 잔 마시기, 5분만 호흡 고르기, "
+                + "내일 꼭 해야 할 일 1개만 적어두기.";
+    }
+
+    private String safeToString(Object o) {
+        try {
+            return String.valueOf(o);
+        } catch (Exception e) {
+            return "<toString failed>";
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,3 +77,5 @@ openai.diary.base-url=${OPENAI_BASE_URL:https://api.openai.com}
 openai.diary.model=${OPENAI_DIARY_MODEL:gpt-5}
 openai.report.base-url=${OPENAI_BASE_URL:https://api.openai.com}
 openai.report.model=${OPENAI_REPORT_MODEL:gpt-5}
+openai.emotion.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+openai.emotion.model=${OPENAI_EMOTION_MODEL:gpt-5}


### PR DESCRIPTION
<!-- commit은 작게, pr은 자세하게 -->

## ⚙️ Related ISSUE Number
<!-- ex) #이슈번호 -->
#14 

<br><br>
## 📄 Work Description
<!-- 작업 내용을 설명해주세요 -->
- OpenAI Responses API 연동을 통해 일일 리포트에 감정 분포(HAPPY/SOSO/SAD/ANGRY/ANXIOUS/THOUGHTFUL) 생성 로직 추가
- dominantEmotion + 감정 통계 + 스니펫 기반 AI 피드백 생성 기능 추가
- OpenAI 호출 실패/비정상 응답에 대한 디버그 로그 및 fallback 처리 보강
  - 4xx 응답 시 status code + error body 출력
  - output_text 비었거나 파싱 실패 시 defaultDist() / 빈 문자열 반환으로 서비스 지속

<br><br>
## 📷 Screenshot
<!-- 동영상, 사진, 로그 등 -->


<br><br>
## 💬 To Reviewers
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<br><br>
## 🔗 Reference
<!— 문제를 해결하면서 도움이 되었거나, 참고했던 사이트 (코드링크) —>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily emotion report feature that automatically analyzes conversations to generate daily summaries with emotion distribution breakdown and AI-generated feedback.
  * New daily report endpoint allowing users to retrieve their emotion analytics and personalized insights.

* **Security**
  * Updated access permissions for report and AI endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->